### PR TITLE
Add grouping by key path

### DIFF
--- a/Asterism/ASTGroup.h
+++ b/Asterism/ASTGroup.h
@@ -33,3 +33,24 @@
 //     grouped[@"odd"];  // { @1, @3, @5 }
 //
 OVERLOADABLE NSDictionary *ASTGroup(id<NSFastEnumeration> collection, id<NSCopying> (^block)(id obj));
+
+// Groups the elements in a collection by their value for a given key path.
+//
+// collection - An object that implements NSFastEnumeration.
+// key path   - A key path for which the elements in `collection` return either
+//              an object that implements NSCopying or nil.
+//              This parameter must not be nil.
+//
+// Returns a dictionary that maps the values the elements return for `keyPath`
+// to a set of all values in `collection` that share the same key.
+//
+// Examples
+//
+//     NSArray *numbers = @[ @"foo", @"bar", @"surprise" ];
+//
+//     NSDictionary *grouped = ASTGroup(numbers, @"length");
+//
+//     grouped[@3]; // { @"foo", @"bar" }
+//     grouped[@8]; // { @"surprise" }
+//
+OVERLOADABLE NSDictionary *ASTGroup(id<NSFastEnumeration> collection, NSString *keyPath);

--- a/Asterism/ASTGroup.m
+++ b/Asterism/ASTGroup.m
@@ -18,10 +18,20 @@ OVERLOADABLE NSDictionary *ASTGroup(id<NSFastEnumeration> collection, id<NSCopyi
     for (id obj in collection) {
         id<NSCopying> key = block(obj);
 
+        if (key == nil) continue;
+
         NSSet *group = dictionary[key] ?: [NSSet set];
 
         dictionary[key] = [group setByAddingObject:obj];
     }
 
     return [dictionary copy];
+}
+
+OVERLOADABLE NSDictionary *ASTGroup(id<NSFastEnumeration> collection, NSString *keyPath) {
+    NSCParameterAssert(keyPath != nil);
+
+    return ASTGroup(collection, ^(id obj) {
+        return [obj valueForKeyPath:keyPath];
+    });
 }

--- a/Specs/ASTGroupSpec.m
+++ b/Specs/ASTGroupSpec.m
@@ -25,4 +25,24 @@ it(@"should return a dictionary of sets, grouped by the blocks return value", ^{
     expect(dictionary[@7]).to.contain(@"Bonjour");
 });
 
+it(@"should remove elements that grouped by `nil`", ^{
+    NSDictionary *dictionary = ASTGroup(@[ @[ @1 ], @[ @2, @3], @[] ], ASTLift0(firstObject));
+
+    expect(dictionary).to.haveCountOf(2);
+
+    expect(dictionary[@1]).to.contain(@[ @1 ]);
+    expect(dictionary[@2]).to.contain(( @[ @2, @3 ] ));
+});
+
+it(@"should return a dictionary of sets, grouped by their value for a key path", ^{
+    NSDictionary *dictionary = ASTGroup(array, @"length");
+
+    expect(dictionary).to.haveCountOf(3);
+
+    expect(dictionary[@3]).to.contain(@"Hej");
+    expect(dictionary[@5]).to.contain(@"Hello");
+    expect(dictionary[@5]).to.contain(@"Hallo");
+    expect(dictionary[@7]).to.contain(@"Bonjour");
+});
+
 SpecEnd


### PR DESCRIPTION
This allows grouping objectivs by their return value for a specific keypath.
