### PR TITLE
Fix object literal syntax in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,11 +15,11 @@ maintaining compile-time safety. For instance, `ASTEach` takes different blocks
 depending on the data structure it operates on:
 
 ```objective-c
-ASTEach([ @"a", @"b", @"c" ], ^(NSNumber *letter) {
+ASTEach(@[ @"a", @"b", @"c" ], ^(NSNumber *letter) {
     NSLog(@"%@", letter);
 });
 
-ASTEach([ @"a", @"b", @"c" ], ^(NSNumber *letter, NSUInteger index) {
+ASTEach(@[ @"a", @"b", @"c" ], ^(NSNumber *letter, NSUInteger index) {
     NSLog(@"%u: %@", index, letter);
 });
 


### PR DESCRIPTION
Note: The same typos exist on https://robb.github.io/Asterism/ but I can't seem to open a pull request for that page.
