### PR TITLE
Don't require git 2.25.0

### DIFF
--- a/script/gen_amalgamation.sh
+++ b/script/gen_amalgamation.sh
@@ -13,7 +13,7 @@ mkdir -p "$TARGET_BASE"
 FILE_BASE="$TARGET_BASE/Asterism"
 HEADER_FILE="$FILE_BASE.h"
 SOURCE_FILE="$FILE_BASE.m"
-GIT_REFERENCE=`git log HEAD -1 --format=reference`
+GIT_REFERENCE=`git log HEAD -1 --pretty='format:%C(auto)%h (%s, %ad)'`
 
 ## GENERATE THE HEADER FILE
 


### PR DESCRIPTION
`--format=reference` was only introduced in git `2.25.0` yet (at least on my Catalina system), git is still `2.24.1`. This format string is equivalent per https://git-scm.com/docs/git-log#_pretty_formats.